### PR TITLE
fix: Calculate string width in pixel

### DIFF
--- a/echo-bar.el
+++ b/echo-bar.el
@@ -137,9 +137,24 @@ If nil, don't update the echo bar automatically."
   ;; Remove the setup function from the minibuffer hook
   (remove-hook 'minibuffer-setup-hook #'echo-bar--minibuffer-setup))
 
+;; TODO: Use function `string-pixel-width' after 29.1
+(defun echo-bar--string-pixel-width (str)
+  "Return the width of STR in pixels."
+  (if (fboundp #'string-pixel-width)
+      (string-pixel-width str)
+    (require 'shr)
+    (shr-string-pixel-width str)))
+
+(defun echo-bar--str-len (str)
+  "Calculate STR in pixel width."
+  (let ((width (frame-char-width))
+        (len (echo-bar--string-pixel-width str)))
+    (+ (/ len width)
+       (if (zerop (% len width)) 0 1))))  ; add one if exceeed
+
 (defun echo-bar-set-text (text)
   "Set the text displayed by the echo bar to TEXT."
-  (let* ((wid (+ (string-width text) echo-bar-right-padding))
+  (let* ((wid (+ (echo-bar--str-len text) echo-bar-right-padding))
          ;; Maximum length for the echo area message before wrap to next line
          (max-len (- (frame-width) wid 5))
          ;; Align the text to the correct width to make it right aligned


### PR DESCRIPTION
This way if you have unicode character in the echo-bar it will still align.

❌ Before: (see the right gap on the right, not good)

![Image 3](https://user-images.githubusercontent.com/8685505/212795651-fb0f2d16-9957-4a42-b5d4-eae88d662fa4.png)

✔️ After:

![Image 2](https://user-images.githubusercontent.com/8685505/212795624-b7f6ac1b-131b-4485-8b08-03960d64abfc.png)
