### PR TITLE
test: Add basic CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version:
+          - 26.3
+          - 27.2
+          - 28.2
+          - snapshot
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: jcs090218/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs-version }}
+
+    - uses: emacs-eask/setup-eask@master
+      with:
+        version: 'snapshot'
+
+    - name: Run tests
+      run:
+        make ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# compiled
+*.elc
+
+# package files
+/.eask
+/dist

--- a/Eask
+++ b/Eask
@@ -1,0 +1,16 @@
+(package "echo-bar"
+         "1.0.0"
+         "Turn the echo area into a custom status bar")
+
+(website-url "https://github.com/qaiviq/echo-bar.el")
+(keywords "convenience" "tools")
+
+(package-file "echo-bar.el")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+(source "gnu")
+
+(depends-on "emacs" "26.1")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+EMACS ?= emacs
+EASK ?= eask
+
+.PHONY: clean checkdoc lint package install compile test
+
+ci: clean package install compile
+
+package:
+	@echo "Packaging..."
+	$(EASK) package
+
+install:
+	@echo "Installing..."
+	$(EASK) install
+
+compile:
+	@echo "Compiling..."
+	$(EASK) compile
+
+test:
+	@echo "Testing..."
+	$(EASK) test ert ./test/*.el
+
+checkdoc:
+	@echo "Run checkdoc..."
+	$(EASK) lint checkdoc
+
+lint:
+	@echo "Run package-lint..."
+	$(EASK) lint package
+
+clean:
+	$(EASK) clean all


### PR DESCRIPTION
I've added CI to this using [Eask](https://github.com/emacs-eask/cli).

Of course, this isn't mandatory. I really like this package, so I think it would be great if it has basic CI.