### PR TITLE
Fix updates

### DIFF
--- a/echo-bar.el
+++ b/echo-bar.el
@@ -209,7 +209,8 @@ overlays."
 (defun echo-bar-update ()
   "Get new text to be displayed from `echo-bar-default-function`."
   (interactive)
-  (echo-bar-set-text (funcall echo-bar-function)))
+  (when echo-bar-mode
+    (echo-bar-set-text (funcall echo-bar-function))))
 
 (defun echo-bar-default-function ()
   "The default function to use for the contents of the echo bar.

--- a/echo-bar.el
+++ b/echo-bar.el
@@ -113,6 +113,7 @@ If nil, don't update the echo bar automatically."
   ;; Start the timer to automatically update
   (when echo-bar-update-interval
     (run-with-timer 0 echo-bar-update-interval 'echo-bar-update))
+  (echo-bar-update) ;; Update immediately
 
   ;; Add the setup function to the minibuffer hook
   (when echo-bar-minibuffer

--- a/echo-bar.el
+++ b/echo-bar.el
@@ -172,7 +172,7 @@ If nil, don't update the echo bar automatically."
 
         (with-current-buffer (overlay-buffer o)
           ;; Wrap the text to the next line if the echo bar text is too long
-          (if (> (point-max) max-len)
+          (if (> (mod (point-max) (frame-width)) max-len)
               (overlay-put o 'after-string (concat "\n" echo-bar-text))
             (overlay-put o 'after-string echo-bar-text)))))
 


### PR DESCRIPTION
Implement 3 fixes:
- `echo-bar-update` is called immediately when `echo-bar` is enabled, regardless of the value of `echo-bar-update-interval` (even if `nil`)
- `echo-bar-update` only updates the echo-bar if enabled (otherwise an interactive call to this function shows the echo-bar without being enabled).
- a new line is added to the overlay only when it would be partially covered by the echo text.