### PR TITLE
fix: Handle multi-lines condition

### DIFF
--- a/echo-bar.el
+++ b/echo-bar.el
@@ -195,9 +195,17 @@ If nil, don't update the echo bar automatically."
 
           (with-current-buffer (overlay-buffer o)
             ;; Wrap the text to the next line if the echo bar text is too long
-            (if (> (mod (point-max) (frame-width)) max-len)
-                (overlay-put o 'after-string (concat "\n" echo-bar-text))
-              (overlay-put o 'after-string echo-bar-text)))))
+            ;;
+            ;; Handle multiple lines; therefore, We only need to consider the
+            ;; last line.
+            (let* ((last-line (save-excursion
+                                (goto-char (point-max))
+                                (thing-at-point 'line)))
+                   (max-width (or (echo-bar--str-len last-line)
+                                  (point-max))))  ; fallback
+              (if (> (mod max-width (frame-width)) max-len)
+                  (overlay-put o 'after-string (concat "\n" echo-bar-text))
+                (overlay-put o 'after-string echo-bar-text))))))
 
       (with-current-buffer " *Minibuf-0*"
         ;; If the minibuffer is not Minibuf-0, then the user is using the minibuffer

--- a/echo-bar.el
+++ b/echo-bar.el
@@ -200,7 +200,7 @@ If nil, don't update the echo bar automatically."
             ;; last line.
             (let* ((last-line (save-excursion
                                 (goto-char (point-max))
-                                (thing-at-point 'line)))
+                                (thing-at-point 'line t)))
                    (max-width (or (echo-bar--str-len last-line)
                                   (point-max))))  ; fallback
               (if (> (mod max-width (frame-width)) max-len)


### PR DESCRIPTION
The newline should only need to consider the last line. 🤔 

#### Before 

![2024-12-15 05 58 20](https://github.com/user-attachments/assets/7cd3d04f-5313-479a-8610-e6606657604b)

#### After

![2024-12-15 05 59 06](https://github.com/user-attachments/assets/87e2931b-6f24-49d8-9cb2-1260b69c5a2b)

cc @benzanol :)